### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lattifai/lattifai-python/security/code-scanning/14](https://github.com/lattifai/lattifai-python/security/code-scanning/14)

To fix the problem, we should add a `permissions` block to the workflow in `.github/workflows/test.yml`. This block should restrict the GITHUB_TOKEN to the minimum necessary privileges, which in this case is likely `contents: read` since the workflow only installs dependencies and runs tests. The best way is to add the `permissions` block near the top of the workflow, so it applies to all jobs, before the `jobs:` key (i.e., after the workflow name and triggers). No further changes are required since the job as defined does not write to the repository or modify issues, PRs, etc.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
