### PR TITLE
Fix Gemini transcription file detection for gemini-3-pro-preview output

### DIFF
--- a/src/lattifai/caption/caption.py
+++ b/src/lattifai/caption/caption.py
@@ -829,8 +829,17 @@ class Caption:
                 content = f.read()
             if cls._is_youtube_vtt_with_word_timestamps(content):
                 return cls._parse_youtube_vtt_with_word_timestamps(content, normalize_text)
-
-        if format == "gemini" or str(caption).endswith("Gemini.md") or str(caption).endswith("Gemini3.md"):
+        
+        #Match Gemini format: explicit format, or files ending with Gemini.md/Gemini3.md,
+        # or files containing "gemini" in the name with .md extension
+        caption_str = str(caption).lower()
+        is_gemini_format = (
+            format == "gemini"
+            or str(caption).endswith("Gemini.md")
+            or str(caption).endswith("Gemini3.md")
+            or ("gemini" in caption_str and caption_str.endswith(".md"))
+        )
+        if is_gemini_format:
             from .gemini_reader import GeminiReader
 
             supervisions = GeminiReader.extract_for_alignment(caption)


### PR DESCRIPTION
When using the gemini-3-pro-preview model for transcription, the generated intermediate Gemini file is named:

  <video_ID>_gemini-3-pro-preview.md

This filename does not match the existing detection logic, which only checks for:
- format == "gemini"
- filenames ending with "Gemini.md"
- filenames ending with "Gemini3.md"

As a result, Gemini transcriptions produced by gemini-3-pro-preview are not recognized correctly and are skipped by the pipeline.

This change updates the detection logic to also handle Gemini files generated by gemini-3-pro-preview, ensuring consistent processing of all Gemini-based transcription outputs.