### PR TITLE
fix: preserve raw transcription string before Caption conversion in _…

### DIFF
--- a/src/lattifai/mixin.py
+++ b/src/lattifai/mixin.py
@@ -427,9 +427,17 @@ class LattifAIClientMixin:
             transcription = await self.transcriber.transcribe_file(media_file, language=source_lang)
             safe_print(colorful.green("         ✓ Transcription completed."))
 
+            # Keep raw transcription for saving to file (before potential conversion)
+            raw_transcription = transcription
+
             if "gemini" in self.transcriber.name.lower():
                 safe_print(colorful.yellow("🔍 Gemini raw output:"))
                 safe_print(colorful.yellow(f"{transcription[:1000]}..."))  # Print first 1000 chars
+
+                # Save to output_dir first (before converting to Caption)
+                if output_dir:
+                    await asyncio.to_thread(self.transcriber.write, raw_transcription, transcript_file, encoding="utf-8")
+                    safe_print(colorful.green(f"         ✓ Transcription saved to: {transcript_file}"))
 
                 # write to temp file and use Caption read
                 # On Windows, we need to close the file before writing to it
@@ -442,7 +450,7 @@ class LattifAIClientMixin:
                 try:
                     await asyncio.to_thread(
                         self.transcriber.write,
-                        transcription,
+                        raw_transcription,
                         tmp_path,
                         encoding="utf-8",
                     )
@@ -460,9 +468,10 @@ class LattifAIClientMixin:
                     if transcription.transcription:
                         safe_print(colorful.yellow(f"First segment: {transcription.transcription[0].text}"))
 
-            if output_dir:
-                await asyncio.to_thread(self.transcriber.write, transcription, transcript_file, encoding="utf-8")
-                safe_print(colorful.green(f"         ✓ Transcription saved to: {transcript_file}"))
+                # Save non-Gemini transcription to file
+                if output_dir:
+                    await asyncio.to_thread(self.transcriber.write, raw_transcription, transcript_file, encoding="utf-8")
+                    safe_print(colorful.green(f"         ✓ Transcription saved to: {transcript_file}"))
 
             return transcription
 


### PR DESCRIPTION
…transcribe

Fix TypeError "data must be str, not Caption" when using Gemini transcription with `lai transcribe align` command.

Bug: When using Gemini models (e.g., gemini-3-pro-preview), the _transcribe() method would:
1. Get transcription as string from transcriber.transcribe_file()
2. Convert it to Caption object via _read_caption() (Gemini branch)
3. Attempt to save using transcriber.write(transcription, ...) AFTER conversion

The save logic was outside the if/else branches, so GeminiTranscriber.write() received a Caption object instead of the expected string.

Fix: 
- Store raw transcription before any conversion: `raw_transcription = transcription`
- Move save logic into each branch (Gemini/non-Gemini) 
- Use raw_transcription for file saving, before Caption conversion
- Also use raw_transcription when writing to temp file for parsing

This ensures GeminiTranscriber.write() always receives a string, and the Caption conversion happens after file saving.